### PR TITLE
Explicitly use new resolver

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,6 @@
 [workspace]
+resolver = "2" # As of Nov 2021, rust doesn't use new resolver if you don't specify this
+
 members = [
     "xb15_core",
     "vl53l0x",


### PR DESCRIPTION
Rust 2021 uses `resolver=2`, but if you are using a cargo workspace, it defaults to the old one. This fixes that.